### PR TITLE
fix: rename .cjs file to .js to ensure proper execution in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/hello-lib.umd.cjs",
-  "module": "./dist/hello-lib.js",
+  "main": "./dist/hello-lib.umd.js",
+  "module": "./dist/hello-lib.es.js",
   "exports": {
     ".": {
-      "import": "./dist/hello-lib.js",
-      "require": "./dist/hello-lib.umd.cjs"
+      "import": "./dist/hello-lib.es.js",
+      "require": "./dist/hello-lib.umd.js"
     }
   },
   "scripts": {

--- a/test/index.html
+++ b/test/index.html
@@ -7,7 +7,7 @@
   <body>
     <h3>Test</h3>
     <div id="hello-container"></div>
-    <script src="../dist/hello-lib.umd.cjs"></script>
+    <script src="../dist/hello-lib.umd.js"></script>
     <script>
       const container = document.getElementById("hello-container");
       HelloLib.init(container);

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,8 @@ export default defineConfig({
     lib: {
       entry: "./src/main.js",
       name: "HelloLib",
+      formats: ["es", "umd"],
+      fileName: (format) => `hello-lib.${format}.js`,
     },
   },
 });


### PR DESCRIPTION
This PR renames the `.cjs` file to `.js` to address an issue where Cloudflare was serving `.cjs` files with the incorrect MIME type (`application/node`), causing the browser to refuse execution. By changing the extension to `.js`, the file is correctly treated as JavaScript (`application/javascript`), resolving the MIME type error and allowing the script to run properly in the browser.
